### PR TITLE
Add minimal C++20 <concepts> header for WASM contracts

### DIFF
--- a/include/concepts
+++ b/include/concepts
@@ -1,0 +1,89 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Minimal <concepts> implementation for CDT WASM contracts.
+// Only provides the subset needed by zpp_bits.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP_CONCEPTS
+#define _LIBCPP_CONCEPTS
+
+#include <type_traits>
+
+namespace std {
+
+// [concept.same]
+template<class T, class U>
+concept same_as = is_same_v<T, U> && is_same_v<U, T>;
+
+// [concept.derived]
+template<class Derived, class Base>
+concept derived_from =
+    is_base_of_v<Base, Derived> &&
+    is_convertible_v<const volatile Derived*, const volatile Base*>;
+
+// [concept.convertible]
+template<class From, class To>
+concept convertible_to =
+    is_convertible_v<From, To> &&
+    requires { static_cast<To>(declval<From>()); };
+
+// [concept.arithmetic]
+template<class T>
+concept integral = is_integral_v<T>;
+
+template<class T>
+concept signed_integral = integral<T> && is_signed_v<T>;
+
+template<class T>
+concept unsigned_integral = integral<T> && !signed_integral<T>;
+
+template<class T>
+concept floating_point = is_floating_point_v<T>;
+
+// [concept.constructible]
+template<class T, class... Args>
+concept constructible_from = is_constructible_v<T, Args...>;
+
+template<class T>
+concept default_initializable = constructible_from<T> && requires { T{}; };
+
+template<class T>
+concept move_constructible = constructible_from<T, T>;
+
+template<class T>
+concept copy_constructible =
+    move_constructible<T> &&
+    constructible_from<T, T&> && convertible_to<T&, T> &&
+    constructible_from<T, const T&> && convertible_to<const T&, T> &&
+    constructible_from<T, const T> && convertible_to<const T, T>;
+
+// [concept.assignable]
+template<class LHS, class RHS>
+concept assignable_from =
+    is_lvalue_reference_v<LHS> &&
+    requires(LHS lhs, RHS&& rhs) {
+        { lhs = static_cast<RHS&&>(rhs) } -> same_as<LHS>;
+    };
+
+// [concept.destructible]
+template<class T>
+concept destructible = is_nothrow_destructible_v<T>;
+
+// [concept.movable]
+template<class T>
+concept movable = is_object_v<T> && move_constructible<T> && assignable_from<T&, T>;
+
+// [concept.copyable]
+template<class T>
+concept copyable = copy_constructible<T> && movable<T> && assignable_from<T&, T&> &&
+    assignable_from<T&, const T&> && assignable_from<T&, const T>;
+
+// [concept.semiregular]
+template<class T>
+concept semiregular = copyable<T> && default_initializable<T>;
+
+} // namespace std
+
+#endif // _LIBCPP_CONCEPTS


### PR DESCRIPTION
Provides core concept definitions (same_as, integral, convertible_to, etc.) needed by zpp_bits for protobuf support in CDT smart contracts.

Until we upgrade cdt-libcxx to C++20.